### PR TITLE
Fix uninitialized constant .. ::TSort

### DIFF
--- a/lib/rukawa/dag.rb
+++ b/lib/rukawa/dag.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'tsort'
 
 module Rukawa
   class Dag


### PR DESCRIPTION

Fix following error.

```
/path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rukawa-0.2.1/lib/rukawa/dag.rb:54:in `singleton class': uninitialized constant #<Class:#<Hash:0x007fae11990ce8>>::TSort (NameError)
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rukawa-0.2.1/lib/rukawa/dag.rb:53:in `tsortable_hash'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rukawa-0.2.1/lib/rukawa/dag.rb:16:in `build'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rukawa-0.2.1/lib/rukawa/job_net.rb:17:in `initialize'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rukawa-0.2.1/lib/rukawa/cli.rb:27:in `new'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rukawa-0.2.1/lib/rukawa/cli.rb:27:in `_run'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /path/to/home/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rukawa-0.2.1/exe/rukawa:6:in `<top (required)>'
	from /path/to/home/.rbenv/gems/2.3.0/bin/rukawa:22:in `load'
	from /path/to/home/.rbenv/gems/2.3.0/bin/rukawa:22:in `<main>'
```

* OSX: 10.11.4
* Ruby: 2.3.0


## test code

```
.
|-- job_nets
|   `-- sample_job_net.rb
`-- jobs
    `-- test1.rb
```

sample_job_net.rb

```ruby
class SampleJobNet < Rukawa::JobNet
  class << self
    def dependencies
      {
        Job1 => [],
        Job2 => [Job1], Job3 => [Job1],
        Job4 => [Job2, Job3],
        Job5 => [Job3],
        Job6 => [Job4, Job5],
        Job7 => [Job6],
      }
    end
  end
end
```

test.rb

```ruby
module ExecuteLog
  def self.store
    @store ||= {}
  end
end

class SampleJob < Rukawa::Job
  def run
    sleep rand(5)
    ExecuteLog.store[self.class] = Time.now
  end
end

class Job1 < SampleJob
end
class Job2 < SampleJob
end
class Job3 < SampleJob
end
class Job4 < SampleJob
end
class Job5 < SampleJob
  def run
    raise "job5 error"
  end
end
class Job6 < SampleJob
  add_skip_rule ->(job) { job.is_a?(Job6) }
end
class Job7 < SampleJob
end

```

```
rukawa run SampleJobNet
```
