### PR TITLE
Fix elapsed time format bug?

### DIFF
--- a/lib/rukawa/abstract_job.rb
+++ b/lib/rukawa/abstract_job.rb
@@ -55,7 +55,7 @@ module Rukawa
       min = elapsed.to_i / 60
       sec = (elapsed - hour * 3600 - min * 60).to_i
 
-      hour_format = min > 0 ? "%dh " % hour : ""
+      hour_format = hour > 0 ? "%dh " % hour : ""
       min_format = min > 0 ? "%dm " % min : ""
       sec_format = "#{sec}s"
       "#{hour_format}#{min_format}#{sec_format}"


### PR DESCRIPTION
strip ``0h`` 

Before 

```
+--------------------------+---------+--------------+
| Job                      | Status  | Elapsed Time |
+--------------------------+---------+--------------+
| XXXXXXXXXXXXXXXXXXXXXJob | running | 0h 1m 57s    |
+--------------------------+---------+--------------+
```

After

```
+--------------------------+---------+--------------+
| Job                      | Status  | Elapsed Time |
+--------------------------+---------+--------------+
| XXXXXXXXXXXXXXXXXXXXXJob | running | 2m 45s       |
+--------------------------+---------+--------------+
```