### PR TITLE
Make no dependency job definition optional

### DIFF
--- a/lib/rukawa/dag.rb
+++ b/lib/rukawa/dag.rb
@@ -92,6 +92,7 @@ module Rukawa
     private
 
     def tsortable_hash(hash)
+      ensure_dependencies_have_all_jobs_as_key!(hash)
       class << hash
         include TSort
         alias :tsort_each_node :each_key
@@ -100,6 +101,14 @@ module Rukawa
         end
       end
       hash
+    end
+
+    def ensure_dependencies_have_all_jobs_as_key!(hash)
+      hash.values.each do |parents|
+        parents.each do |j|
+          hash[j] ||= []
+        end
+      end
     end
 
     class Edge

--- a/sample/job_nets/sample_job_net.rb
+++ b/sample/job_nets/sample_job_net.rb
@@ -2,8 +2,6 @@ class InnerJobNet < Rukawa::JobNet
   class << self
     def dependencies
       {
-        InnerJob3 => [],
-        InnerJob1 => [],
         InnerJob2 => [InnerJob1, InnerJob3],
       }
     end
@@ -14,7 +12,6 @@ class InnerJobNet2 < Rukawa::JobNet
   class << self
     def dependencies
       {
-        InnerJob4 => [],
         InnerJob5 => [InnerJob4],
         InnerJob6 => [InnerJob4, InnerJob5],
       }
@@ -26,8 +23,6 @@ class InnerJobNet3 < Rukawa::JobNet
   class << self
     def dependencies
       {
-        InnerJob7 => [],
-        InnerJob8 => [],
         InnerJob9 => [InnerJob7, InnerJob8],
         InnerJob10 => [InnerJob7, InnerJob8],
       }
@@ -39,9 +34,6 @@ class InnerJobNet4 < Rukawa::JobNet
   class << self
     def dependencies
       {
-        InnerJob11 => [],
-        InnerJob12 => [],
-        InnerJob13 => [],
         NestedJobNet => [InnerJob11, InnerJob12],
       }
     end
@@ -52,7 +44,6 @@ class NestedJobNet < Rukawa::JobNet
   class << self
     def dependencies
       {
-        NestedJob1 => [],
         NestedJob2 => [NestedJob1],
       }
     end

--- a/spec/rukawa_spec.rb
+++ b/spec/rukawa_spec.rb
@@ -43,25 +43,36 @@ describe Rukawa do
           set << n
         end
       end
+      j.dependencies.each_value do |parents|
+        parents.each do |n|
+          if n.respond_to?(:dependencies)
+            collect_jobs.call(n, set)
+          else
+            set << n
+          end
+        end
+      end
     }
     collect_jobs.call(SampleJobNet, job_classes)
 
-    assert { job_net.dag.jobs.size == job_classes.size}
+    aggregate_failures do
+      assert { job_net.dag.jobs.size == job_classes.size}
 
-    job4 = find_job(job_net, Job4)
-    expect(job4.in_comings.map(&:from)).to match_array([an_instance_of(Job2), an_instance_of(Job3)])
+      job4 = find_job(job_net, Job4)
+      expect(job4.in_comings.map(&:from)).to match_array([an_instance_of(Job2), an_instance_of(Job3)])
 
-    job8 = find_job(job_net, Job8)
-    expect(job8.in_comings.map(&:from)).to match_array([an_instance_of(InnerJob2)])
-    expect(job8.out_goings.map(&:to)).to match_array([an_instance_of(InnerJob7), an_instance_of(InnerJob8)])
+      job8 = find_job(job_net, Job8)
+      expect(job8.in_comings.map(&:from)).to match_array([an_instance_of(InnerJob2)])
+      expect(job8.out_goings.map(&:to)).to match_array([an_instance_of(InnerJob7), an_instance_of(InnerJob8)])
 
-    inner_job11 = find_job(job_net, InnerJob11)
-    expect(inner_job11.in_comings.map(&:from)).to match_array([an_instance_of(InnerJob9), an_instance_of(InnerJob10)])
-    expect(inner_job11.out_goings.map(&:to)).to match_array([an_instance_of(NestedJob1)])
+      inner_job11 = find_job(job_net, InnerJob11)
+      expect(inner_job11.in_comings.map(&:from)).to match_array([an_instance_of(InnerJob9), an_instance_of(InnerJob10)])
+      expect(inner_job11.out_goings.map(&:to)).to match_array([an_instance_of(NestedJob1)])
 
-    inner_job12 = find_job(job_net, InnerJob12)
-    expect(inner_job12.in_comings.map(&:from)).to match_array([an_instance_of(InnerJob9), an_instance_of(InnerJob10)])
-    expect(inner_job12.out_goings.map(&:to)).to match_array([an_instance_of(NestedJob1)])
+      inner_job12 = find_job(job_net, InnerJob12)
+      expect(inner_job12.in_comings.map(&:from)).to match_array([an_instance_of(InnerJob9), an_instance_of(InnerJob10)])
+      expect(inner_job12.out_goings.map(&:to)).to match_array([an_instance_of(NestedJob1)])
+    end
   end
 
   it 'skip hierarchy' do


### PR DESCRIPTION
```ruby
def self.dependencies
  {
    Job1 => [], # This line is no longer necessary
    Job2 => [Job1],
  }
end
```