### PR TITLE
Use ActiveSupport::Cache::RedisCacheStore if ActiveSupport > 5.2

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,11 @@ Dir.glob(File.expand_path('../../sample/jobs/**/*.rb', __FILE__)).each { |f| req
 
 redis_host = ENV["REDIS_HOST"] || "localhost:6379"
 Rukawa.configure do |c|
-  c.status_store = ActiveSupport::Cache::RedisStore.new(redis_host)
+  c.status_store = if ActiveSupport.version >= Gem::Version.new("5.2")
+                     ActiveSupport::Cache::RedisCacheStore.new(url: "redis://#{redis_host}")
+                   else
+                     ActiveSupport::Cache::RedisStore.new(redis_host)
+                   end
 end
 
 Rukawa.config.status_store.write("rukawa.test", "test", expires_in: 60)


### PR DESCRIPTION
Rails 5.2.0 includes a Redis cache store out of the box

* https://github.com/rails/rails/pull/31134
* https://github.com/redis-store/redis-activesupport
    * > This gem is in LTS mode.
