### PR TITLE
Waffle.io was shut down

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Stories in Ready](https://badge.waffle.io/joker1007/rukawa.png?label=ready&title=Ready)](https://waffle.io/joker1007/rukawa)
 # Rukawa
 [![Gem Version](https://badge.fury.io/rb/rukawa.svg)](https://badge.fury.io/rb/rukawa)
 [![Build Status](https://travis-ci.org/joker1007/rukawa.svg?branch=master)](https://travis-ci.org/joker1007/rukawa)


### PR DESCRIPTION
* https://waffle.io/closing-its-doors (can't access)
* https://web.archive.org/web/20190317040044/https://waffle.io/closing-its-doors

They said that.

> With a heavy heart, we are announcing today that we will be closing our doors at Waffle on May 16, 2019.