### PR TITLE
Run spec in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: test
+
+on:
+  push:
+    branches:
+      - '*'
+
+  pull_request:
+  # schedule:
+  #   cron: '0 0 * * 0' # every Sunday at 00:00 (UTC)
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby:
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
+    services:
+      redis:
+        image: redis
+        options: >-
+            --health-cmd "redis-cli ping"
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake spec
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rukawa
 [![Gem Version](https://badge.fury.io/rb/rukawa.svg)](https://badge.fury.io/rb/rukawa)
-[![Build Status](https://travis-ci.org/joker1007/rukawa.svg?branch=master)](https://travis-ci.org/joker1007/rukawa)
+[![test](https://github.com/joker1007/rukawa/actions/workflows/test.yml/badge.svg)](https://github.com/joker1007/rukawa/actions/workflows/test.yml)
 [![Code Climate](https://codeclimate.com/github/joker1007/rukawa/badges/gpa.svg)](https://codeclimate.com/github/joker1007/rukawa)
 
 Rukawa = (流川)

--- a/rukawa.gemspec
+++ b/rukawa.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 4"
+  spec.add_runtime_dependency "activesupport", ">= 4", "< 7"
   spec.add_runtime_dependency "concurrent-ruby"
   spec.add_runtime_dependency "thor"
   spec.add_runtime_dependency "terminal-table"


### PR DESCRIPTION
## Problem

My previous pull requests are not tested on travis-ci.org. And the last spec was invoked 7 months ago.
https://travis-ci.org/github/joker1007/rukawa/builds

## What is this patch

* Run `bundle exec rake spec` on GitHub Actions
    * https://github.com/unasuke/rukawa/actions/runs/1701239984
    * redis-activesupport doesn't support ActiveSupport 7 so set ActiveSupoort version constraint to lower than 7
        * https://rubygems.org/gems/redis-activesupport
* Update README badge