### PR TITLE
Replace `File.exists?` with `File.exist?` for compatibility with Ruby 3.2

### DIFF
--- a/lib/rukawa/cli.rb
+++ b/lib/rukawa/cli.rb
@@ -114,7 +114,7 @@ module Rukawa
       if options[:config]
         load File.expand_path(options[:config], Dir.pwd)
       else
-        load default_config_file if File.exists?(default_config_file)
+        load default_config_file if File.exist?(default_config_file)
       end
 
       Rukawa.configure do |c|


### PR DESCRIPTION
`File.exists?` has been replaced with `File.exist?` and removed in Ruby 3.2.
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/#:~:text=Struct%3A%3APasswd-,removed%20methods,-The%20following%20deprecated

This PR replaces it for compatibility.