### PR TITLE
Remove deprecated auto_terminate option

### DIFF
--- a/lib/rukawa/context.rb
+++ b/lib/rukawa/context.rb
@@ -6,7 +6,6 @@ module Rukawa
       @concurrency = concurrency || Rukawa.config.concurrency
       @store = Concurrent::Hash.new
       @executor = Concurrent::CachedThreadPool.new
-      @executor.auto_terminate = true
       @semaphore = Concurrent::Semaphore.new(@concurrency)
     end
 


### PR DESCRIPTION
Due to the change in https://github.com/ruby-concurrency/concurrent-ruby/pull/841, the `auto_terminate` option has become deprecated, and specifying it has no effect. 
Since the default value of this is true, I simply removed it.

```
WARN -- Concurrent::CachedThreadPool: [DEPRECATED] Method #auto_terminate= has no effect. Set :auto_terminate option when executor is initialized.
```